### PR TITLE
Use alpine:3.14 as base docker image

### DIFF
--- a/skeleton-model-app/market/Dockerfile
+++ b/skeleton-model-app/market/Dockerfile
@@ -1,4 +1,6 @@
-FROM 958130917597.dkr.ecr.ap-southeast-1.amazonaws.com/node:14.15.5-alpine3.13
+FROM alpine:3.14
+
+RUN apk add --no-cache yarn
 
 COPY . /demo
 

--- a/skeleton-model-app/service-provider/Dockerfile
+++ b/skeleton-model-app/service-provider/Dockerfile
@@ -1,4 +1,6 @@
-FROM 958130917597.dkr.ecr.ap-southeast-1.amazonaws.com/node:14.15.5-alpine3.13
+FROM alpine:3.14
+
+RUN apk add --no-cache yarn
 
 COPY . /demo
 


### PR DESCRIPTION
We should use alpine:3.14 as the base docker image, as ECR is not accessible